### PR TITLE
Remove empty arrays from $data['middleware']

### DIFF
--- a/resources/views/collectors/request.blade.php
+++ b/resources/views/collectors/request.blade.php
@@ -49,7 +49,7 @@ if ($statusCode > 400) {
             <div class="sf-toolbar-info-piece">
                 <b>Middleware</b>
                 <span>
-                    {{ implode(', ', $data['middleware']) }}
+                    {{ implode(', ', array_filter($data['middleware'])) }}
                 </span>
             </div>
 


### PR DESCRIPTION
When middleware contains any empty array's an error is thrown: `Array to string conversion` using `array_filter($data['middleware'])` removes any empty arrays.