### PR TITLE
changed header to headers->set

### DIFF
--- a/src/Toolbar.php
+++ b/src/Toolbar.php
@@ -81,8 +81,8 @@ class Toolbar
 
         // Inject headers in Ajax Requests
         if ($request->ajax()) {
-            $response->header('x-debug-token', $this->getDebugToken($request));
-            $response->header('x-debug-token-link', route('telescope-toolbar.show', [$this->getDebugToken($request)]));
+            $response->headers->set('x-debug-token', $this->getDebugToken($request));
+            $response->headers->set('x-debug-token-link', route('telescope-toolbar.show', [$this->getDebugToken($request)]));
 
             return;
         }


### PR DESCRIPTION
when using ajax I was getting the error:

```
Call to undefined method Symfony\Component\HttpFoundation\JsonResponse::header
```

I tracked it down to the header response, changing it to headers->set corrected this error.

I changed:

```php
$response->header('x-debug-token', $this->getDebugToken($request));
$response->header('x-debug-token-link', route('telescope-toolbar.show', [$this->getDebugToken($request)]));
```

To
```php
$response->headers->set('x-debug-token', $this->getDebugToken($request));
$response->headers->set('x-debug-token-link', route('telescope-toolbar.show', [$this->getDebugToken($request)]));
```