### PR TITLE
Import route facade

### DIFF
--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+
 Route::get('/render/{token}', 'ToolbarController@render')->name('telescope-toolbar.render');
 Route::get('/show/{token}/{tab?}', 'ToolbarController@show')->name('telescope-toolbar.show');
 Route::get('/assets/base.js', 'ToolbarController@baseJs')->name('telescope-toolbar.baseJs');


### PR DESCRIPTION
When running Laravel without class aliasses the package breaks because of the missing import of the route facade.