### PR TITLE
Adding back route facade import

### DIFF
--- a/src/Http/assets.php
+++ b/src/Http/assets.php
@@ -1,4 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+
 Route::get('base.js', 'ToolbarController@baseJs')->name('telescope-toolbar.baseJs');
 Route::get('styling.css', 'ToolbarController@styling')->name('telescope-toolbar.styling');

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,4 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+
 Route::get('render/{token}', 'ToolbarController@render')->name('telescope-toolbar.render');
 Route::get('show/{token}/{tab?}', 'ToolbarController@show')->name('telescope-toolbar.show');


### PR DESCRIPTION
Import was added in #13 but after the latest commit on routes.php the import is removed again. 

So for applications without class aliases, the package is breaking again as mentioned in #13 