### PR TITLE
Update for laravel/telescope 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
   "require": {
     "php": "^7.1.3",
     "ext-json": "*",
-    "laravel/framework": "^5.8|^6",
-    "laravel/telescope": "^2.1"
+    "laravel/framework": "^6",
+    "laravel/telescope": "^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Telescope got updated to 3.0, dropping support for laravel 5.8.

This pull request updates the telescope and laravel dependency