### PR TITLE
Support telescope 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "php": "^7.1.3",
     "ext-json": "*",
     "laravel/framework": "^5.8|^6",
-    "laravel/telescope": "^2.1"
+    "laravel/telescope": "^2.1|^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Add support for telescope 3.0 that removed support for laravel 5.8 but the toolbar can still support both. (#17)