### PR TITLE
Add separate environment variable for toolbar

### DIFF
--- a/config/telescope-toolbar.php
+++ b/config/telescope-toolbar.php
@@ -13,7 +13,7 @@ return [
     | enabled and Laravel needs to be in Debug mode.
     |
     */
-    'enabled' => env('TELESCOPE_ENABLED', true),
+    'enabled' => env('TELESCOPE_TOOLBAR_ENABLED', env('TELESCOPE_ENABLED', true)),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a new environment variable `TELESCOPE_TOOLBAR_ENABLED` which can be used to disable telescope toolbar even if Telescope is enabled (which one cannot do with the current setup).

If the environment variable is not provided, then it will default to the current setting, which is to use the same environment variable used to enable/disable Laravel Telescope.

Why to implement this? Because there are cases where one would like to disable the Toolbar while still having Laravel Telescope enabled. This could be while working on some frontend stuff where the toolbar should be disabled.