### PR TITLE
Add auto night theme

### DIFF
--- a/resources/views/head.blade.php
+++ b/resources/views/head.blade.php
@@ -1,7 +1,12 @@
 
 <!-- Start of Telescope Toolbar assets !-->
 <script src="{{ route('telescope-toolbar.baseJs') }}?{{ $assetVersion }}"></script>
-<link href="{{ route('telescope-toolbar.styling') }}?{{ $assetVersion }}&lightMode={{ $lightMode }}" rel="stylesheet">
+@if ($lightMode !== 'auto')
+    <link href="{{ route('telescope-toolbar.styling') }}?{{ $assetVersion }}&lightMode={{ $lightMode }}" rel="stylesheet">
+@else
+    <link href="{{ route('telescope-toolbar.styling') }}?{{ $assetVersion }}&lightMode=1" rel="stylesheet">
+    <link href="{{ route('telescope-toolbar.styling') }}?{{ $assetVersion }}&lightMode=0" media="(prefers-color-scheme: dark)" rel="stylesheet">
+@endif
 <script @if(isset($csp_script_nonce) && $csp_script_nonce) nonce="{{ $csp_script_nonce }}" @endif>/*<![CDATA[*/
     (function () {
         @foreach ($requestStack as $request)

--- a/src/Toolbar.php
+++ b/src/Toolbar.php
@@ -128,7 +128,8 @@ class Toolbar
 
         $head = View::make('telescope-toolbar::head', [
             'assetVersion' => static::ASSET_VERSION,
-            'lightMode' => config('telescope-toolbar.light_theme') ? 1 : 0,
+            'lightMode' => config('telescope-toolbar.light_theme') === 'auto' ? 'auto'
+                        : (config('telescope-toolbar.light_theme') ? 1 : 0),
             'requestStack' => $this->getRequestStack($request, $response),
         ])->render();
 


### PR DESCRIPTION
I added 'auto' option for the light theme option in config so it imports both of css files that styles light and dark mode so that toolbar should automatically detect if the user has requested a light or dark theme based on the operating system's or browser's settings.