### PR TITLE
Syntax fix (missing semicolon)

### DIFF
--- a/resources/views/base_js.blade.php
+++ b/resources/views/base_js.blade.php
@@ -96,7 +96,7 @@
             var newState = Sfjs.getPreference('toolbar/ajax/replace') !== 'manual' ?  'manual' : 'auto' ;
             Sfjs.setPreference('toolbar/ajax/replace', newState);
             document.querySelector('.sf-toolbar-ajax-replace-state').innerHTML =  newState === 'manual' ? 'Manual' : 'Auto';
-        }
+        };
 
         var successStreak = 4;
         var pendingRequests = 0;


### PR DESCRIPTION
Missing semicolon causes "unexpected token: keyword 'var'" error.