### PR TITLE
Fix toolbar icon shift on closing

### DIFF
--- a/resources/css/custom.css
+++ b/resources/css/custom.css
@@ -49,4 +49,5 @@
 
 .sf-minitoolbar .open-button svg {
     max-height: 18px;
+    margin-top: 4px;
 }


### PR DESCRIPTION
This fixes an annoying bug where the icon shifts 4px up when closing the toolbar:

![Bildschirmfoto 2023-08-06 um 20 58 42](https://github.com/fruitcake/laravel-telescope-toolbar/assets/66938161/3d623f6e-1260-4a44-89ea-be59d064c893) ![Bildschirmfoto 2023-08-06 um 20 58 38](https://github.com/fruitcake/laravel-telescope-toolbar/assets/66938161/26c30a05-491d-4299-92f3-4abf18f573a8)
