### PR TITLE
Updated README to document TELESCOPE_TOOLBAR_ENABLED usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ composer require fruitcake/laravel-telescope-toolbar --dev
 ```
 
 The Toolbar will show by default when Telescope is enabled and APP_DEBUG is true.
+It can also enabled or disabled using the `TELESCOPE_TOOLBAR_ENABLED` environment variable.
 
 ![image](https://user-images.githubusercontent.com/973269/63676710-d79ad000-c7eb-11e9-8793-c58c6bc25bbe.png)
 


### PR DESCRIPTION
Hello!

I love this package, and I have been using it for years.
Sometimes, I hide the debug bar to see the full app when working on UI tasks.
I always forget how to enable/disable it and find myself coming to the project readme, not finding and then having to search through issues.

It would be great if the `TELESCOPE_TOOLBAR_ENABLED` env variable were documented front and centre!

No worries if this is inappropriate and there is a reason for not being in the readme!

All the best