### PR TITLE
Add compatiblity for Laravel Telescope 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^8",
         "ext-json": "*",
         "laravel/framework": "^9|^10|^11.0",
-        "laravel/telescope": "^4"
+        "laravel/telescope": "^4|^5"
     },
     "require-dev": {
         "orchestra/testbench-dusk": "^6|^7|^8"

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,10 @@ First install Telescope and check it works (see https://laravel.com/docs/master/
 ```bash
 composer require laravel/telescope
 php artisan telescope:install
+
+# Telescope 5.0 no longer automatically loads migrations from its own migrations directory. Instead, you should run the following command to publish Telescope's migrations to your application:
+php artisan vendor:publish --tag=telescope-migrations
+
 php artisan migrate
 ```
 


### PR DESCRIPTION
The package already supports the Laravel 11, but Laravel/Telescope 5 supports Laravel 11 only. So there will be conflict to update your application.

Telescope 5.x:
- upgrade guide: https://github.com/laravel/telescope/blob/5.x/UPGRADE.md
- changelog: https://github.com/laravel/telescope/blob/5.x/CHANGELOG.md