### PR TITLE
add configurable option to open telescope links in new tab

### DIFF
--- a/config/telescope-toolbar.php
+++ b/config/telescope-toolbar.php
@@ -41,6 +41,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Open links in new tab
+    |--------------------------------------------------------------------------
+    |
+    | This option enabled/disables opening telescope links in a new tab.
+    | By default, clicking on a tab will open telescope in the same tab.
+    | Values be: true, false
+    |
+    */
+    'new_tab' => env('TELESCOPE_TOOLBAR_NEW_TAB', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Route path of Toolbar
     |--------------------------------------------------------------------------
     |
@@ -168,9 +180,7 @@ return [
         EntryType::REDIS => [
             'telescope-toolbar::collectors.redis',
         ],
-        EntryType::SCHEDULED_TASK => [
-
-        ],
+        EntryType::SCHEDULED_TASK => [],
     ],
 
 ];

--- a/config/telescope-toolbar.php
+++ b/config/telescope-toolbar.php
@@ -180,7 +180,9 @@ return [
         EntryType::REDIS => [
             'telescope-toolbar::collectors.redis',
         ],
-        EntryType::SCHEDULED_TASK => [],
+        EntryType::SCHEDULED_TASK => [
+    
+        ],
     ],
 
 ];

--- a/config/telescope-toolbar.php
+++ b/config/telescope-toolbar.php
@@ -181,7 +181,7 @@ return [
             'telescope-toolbar::collectors.redis',
         ],
         EntryType::SCHEDULED_TASK => [
-    
+
         ],
     ],
 

--- a/resources/views/item.blade.php
+++ b/resources/views/item.blade.php
@@ -8,7 +8,7 @@
                 $link = $ttLink . $link;
             }
         @endphp
-        <a href="{{ $link }}">
+        <a href="{{ $link }}" {{ config('telescope-toolbar.new_tab') ? 'target="_blank"' : '' }}>
     @endif
         <div class="sf-toolbar-icon">{{ $icon ?? '' }}</div>
         @if(isset($link) && $link)</a>@endif


### PR DESCRIPTION
I would like to be able to configure if links to telescope opens in a new tab.
This pull request would implement that feature and make it configurable.