### PR TITLE
Fix comment text of `Use Telescope Theme`

### DIFF
--- a/config/telescope-toolbar.php
+++ b/config/telescope-toolbar.php
@@ -33,8 +33,8 @@ return [
     |
     | This option enabled/disables the Light Theme.
     | Laravel Telescope toolbar has two themes; Light and Dark.
-    | By default is uses the preferred color scheme of the browser.
-    | Values be: true, false or 'auto' (default)
+    | By default is uses dark theme.
+    | Values be: 'auto', true, or false (default)
     |
     */
     'light_theme' => env('TELESCOPE_LIGHT_THEME', false),


### PR DESCRIPTION
The default value has been changed to `false` on https://github.com/fruitcake/laravel-telescope-toolbar/commit/9c1d4d04c1d5838ee2422b952661c9c91186f1c4